### PR TITLE
get the project to `dune build`

### DIFF
--- a/src/ast.mli
+++ b/src/ast.mli
@@ -1,0 +1,3 @@
+
+type program = 
+    Program

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,8 @@
 (executable 
   (name fly)
-  (modules fly))
+  (modules fly scanner parser ast)
+  (modules_without_implementation ast)
+)
+
+(ocamllex scanner)
+(ocamlyacc parser)

--- a/src/fly.ml
+++ b/src/fly.ml
@@ -1,3 +1,7 @@
+open Printf
+
+(* open Scanner *)
+open Parser
 
 let get_token_list lexbuf = 
     let rec work acc = 
@@ -10,12 +14,13 @@ let pp_token = function
     | EQ -> "="
     | DIVIDE -> "/"
     | LITERAL(i) -> sprintf "%d" i
-    | VARIABLE(v) -> sprintf ":%s:" v
+    | ID(v) -> sprintf ":%s:" v
     | SEMI -> ";"
     | PLUS -> "+"
     | MINUS -> "-"
     | TIMES -> "*"
     | EOF -> "EOF"
+    | _ -> "??"
 
 
 let _ =

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -34,3 +34,4 @@ open Ast
 %%
 
 program_rule:
+     { Program }

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -1,5 +1,5 @@
 {
-    open Pparser
+    open Parser
 }
 
 rule tokenize = parse
@@ -11,6 +11,6 @@ rule tokenize = parse
 | '=' { EQ }
 | ';' { SEMI } 
 | ['0'-'9']+ as lit { LITERAL(int_of_string lit) }
-| ['a'-'z']+ as id  { VARIABLE(id) } 
+| ['a'-'z']+ as id  { ID(id) } 
 | eof { EOF }
 


### PR DESCRIPTION
Now we've connected parser.mly and scanner.mll to connect to fly.ml using dune.

This means we can build with `dune build` and run the build with `dune exec fly.exe` (or directly with `./build/default/src/fly.exe`). 

This also means that all the build files are hidden from our source directory, unlike in the homework where our directories looked somewhat like this:

```
❯ l
total 424
drwxr-xr-x@ 22 kristoferfannar  staff   704B Apr  2 14:34 .
drwxr-xr-x  24 kristoferfannar  staff   768B Mar 26 23:12 ..
-rw-rw-r--@  1 kristoferfannar  staff   1.2K Mar  1  2022 Makefile
-rw-r--r--   1 kristoferfannar  staff   540B Mar 26 22:22 ast.cmi
-rw-rw-r--@  1 kristoferfannar  staff   168B Mar 26 17:48 ast.mli
-rwxr-xr-x   1 kristoferfannar  staff   130K Apr  2 14:34 calc
-rw-r--r--   1 kristoferfannar  staff   2.9K Mar 26 22:55 calc.cmi
-rw-r--r--   1 kristoferfannar  staff   1.3K Apr  2 14:34 calc.cmo
-rw-rw-r--@  1 kristoferfannar  staff   2.1K Apr  2 14:34 calc.ml
-rw-r--r--   1 kristoferfannar  staff     0B Mar 26 22:57 calc.mli
-rw-r--r--   1 kristoferfannar  staff     3B Apr  2 14:34 calc.out
-rw-rw-r--@  1 kristoferfannar  staff    40B Mar 26 22:15 calc.tb
-rw-r--r--   1 kristoferfannar  staff   683B Apr  2 14:34 parser.cmi
-rw-r--r--   1 kristoferfannar  staff   3.1K Apr  2 14:34 parser.cmo
-rw-r--r--   1 kristoferfannar  staff   8.7K Apr  2 14:34 parser.ml
-rw-r--r--   1 kristoferfannar  staff   282B Apr  2 14:34 parser.mli
-rw-rw-r--@  1 kristoferfannar  staff   502B Mar 30 10:51 parser.mly
-rw-r--r--   1 kristoferfannar  staff   512B Mar 26 22:54 scanner.cmi
-rw-r--r--   1 kristoferfannar  staff   2.0K Apr  2 14:34 scanner.cmo
-rw-r--r--   1 kristoferfannar  staff   6.8K Mar 26 22:54 scanner.ml
-rw-r--r--   1 kristoferfannar  staff     0B Mar 26 22:58 scanner.mli
-rw-rw-r--@  1 kristoferfannar  staff   280B Mar 25 01:50 scanner.mll
```