### PR TITLE
Setup cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,41 @@
 
 This repository holds the source code for the Fly compiler
 
+## Usage
+
+The fly compiler processes a `.fly` file provided in the program arguments, or reads a fly program through stdin if no file is provided.
+
+By default, the fly compiler produces a `fly.out` executable from the given program.
+However, that behaviour is changed with the following flags:
+
+- `--tokens`: prints the program's tokens to stdout
+- `--ast`: prints the program's ast to stdout
+- `--ir`: prints the program's llvm IR to stdout
+
+### Example
+
+```bash
+❯ ./fly --help
+Usage: ./fly <filename>.fly
+  --tokens Print Tokens to stdout
+  --ast Print Ast to stdout
+  --ir Print IR to stdout
+  -help  Display this list of options
+  --help  Display this list of options
+
+# produce a "fly.out" executable from the program
+❯ ./fly main.fly
+
+# produce the program's tokens to stdout
+❯ ./fly --tokens main.fly
+
+# produce the program's ast to stdout
+❯ ./fly --ast main.fly
+
+# produce the program's llvm IR to stdout
+❯ ./fly --ir main.fly
+```
+
 ## Building
 
 ### Environment Setup
@@ -12,7 +47,7 @@ If you don't have opam, we recommend installing it through homebrew (Mac).
 Mac (homebrew):
 
 ```bash
-brew install opam
+❯ brew install opam
 ```
 
 Also, the project requires `llvm@14` on your machine.

--- a/bin/fly.ml
+++ b/bin/fly.ml
@@ -7,6 +7,7 @@ type action =
   | IR
   | Code
 
+(* By default, generate code *)
 let act = ref Code
 let set_action a () = act := a
 

--- a/bin/fly.ml
+++ b/bin/fly.ml
@@ -1,29 +1,57 @@
-(* open Printf
+open Fly_lib
 
-let get_token_list lexbuf =
-  let rec work acc =
-    match Scanner.tokenize lexbuf with
-    | EOF -> acc
-    | t -> work (t :: acc)
-  in
-  List.rev (work [])
+type action =
+  | Tokens
+  | Ast
+  | IR
+  | Code
+
+let act = ref Code
+let set_action a () = act := a
+
+let speclist =
+  [ "--tokens", Arg.Unit (set_action Tokens), "Print Tokens to stdout"
+  ; "--ast", Arg.Unit (set_action Ast), "Print Ast to stdout"
+  ; "--ir", Arg.Unit (set_action IR), "Print IR to stdout"
+  ]
 ;;
 
-let pp_token = function
-  | EQ -> "="
-  | DIVIDE -> "/"
-  | LITERAL i -> sprintf "%d" i
-  | ID v -> sprintf ":%s:" v
-  | SEMI -> ";"
-  | PLUS -> "+"
-  | MINUS -> "-"
-  | TIMES -> "*"
-  | EOF -> "EOF"
-  | _ -> "??"
+let usg = "Usage: ./fly <filename>.fly"
+
+let rec to_token_list lexbuf =
+  let tk = Fly_lib.Scanner.tokenize lexbuf in
+  match tk with
+  | EOF -> []
+  | t -> t :: to_token_list lexbuf
 ;;
 
-let _ =
-  let lexbuf = Lexing.from_channel stdin in
-  (* Debug Tokens *)
-  let token_list = get_token_list lexbuf in
-  List.map pp_token token_list |> List.iter (printf "%s\n") *)
+let read_and_print_tokens channel =
+  try
+    while true do
+      let line = input_line channel in
+      let tokens = to_token_list (Lexing.from_string line) in
+      print_endline (Utils.string_of_tokens tokens)
+    done
+  with
+  | End_of_file -> close_in_noerr channel
+  | e ->
+    close_in_noerr channel;
+    raise e
+;;
+
+let read_and_print_ast channel =
+  let lexbuf = Lexing.from_channel channel in
+  let ast = Fly_lib.Parser.program_rule Fly_lib.Scanner.tokenize lexbuf in
+  print_endline (Utils.string_of_program ast)
+;;
+
+let () =
+  let channel = ref stdin in
+  Arg.parse speclist (fun filename -> channel := open_in filename) usg;
+  (* read !channel *)
+  (* let lexbuf = Lexing.from_channel !channel in *)
+  match !act with
+  | Tokens -> read_and_print_tokens !channel
+  | Ast -> read_and_print_ast !channel
+  | _ -> raise (Failure "not implemented")
+;;

--- a/bin/fly.ml
+++ b/bin/fly.ml
@@ -80,7 +80,7 @@ let read_and_compile channel =
   let asmstr = Llvm.MemoryBuffer.as_string asmbuf in
 
   (* Compile asm to an executable using gcc - reading the asm from stdin *)
-  let argv = [ "gcc"; "-x"; "assembler"; "/dev/stdin"; "-o"; exe_name] in
+  let argv = [ "gcc"; "-x"; "assembler"; "/dev/stdin"; "-o"; exe_name ] in
   let cmd = String.concat " " argv in
   let child_stdout, child_stdin = Unix.open_process cmd in
 

--- a/bin/fly.ml
+++ b/bin/fly.ml
@@ -19,6 +19,7 @@ let speclist =
 ;;
 
 let usg = "Usage: ./fly <filename>.fly"
+let exe_name = "fly.out"
 
 let rec to_token_list lexbuf =
   let tk = Fly_lib.Scanner.tokenize lexbuf in
@@ -79,7 +80,7 @@ let read_and_compile channel =
   let asmstr = Llvm.MemoryBuffer.as_string asmbuf in
 
   (* Compile asm to an executable using gcc - reading the asm from stdin *)
-  let argv = [ "gcc"; "-x"; "assembler"; "/dev/stdin"; "-o"; "a.out" ] in
+  let argv = [ "gcc"; "-x"; "assembler"; "/dev/stdin"; "-o"; exe_name] in
   let cmd = String.concat " " argv in
   let child_stdout, child_stdin = Unix.open_process cmd in
 

--- a/bin/fly.ml
+++ b/bin/fly.ml
@@ -1,4 +1,5 @@
 open Fly_lib
+module L = Llvm
 
 type action =
   | Tokens
@@ -45,13 +46,66 @@ let read_and_print_ast channel =
   print_endline (Utils.string_of_program ast)
 ;;
 
+let read_and_print_ir channel =
+  let lexbuf = Lexing.from_channel channel in
+  let ast = Fly_lib.Parser.program_rule Fly_lib.Scanner.tokenize lexbuf in
+  let sast = Semant.check ast.body in
+  let md = Irgen.translate sast in
+  print_endline (L.string_of_llmodule md)
+;;
+
+let read_and_compile channel =
+  let lexbuf = Lexing.from_channel channel in
+  let ast = Fly_lib.Parser.program_rule Fly_lib.Scanner.tokenize lexbuf in
+  let sast = Semant.check ast.body in
+  let md = Irgen.translate sast in
+
+  (* Inititalize triples that llvm needs to create a target *)
+  Llvm_all_backends.initialize ();
+  let triple = Llvm_target.Target.default_triple () in
+  let tm =
+    Llvm_target.TargetMachine.create ~triple (Llvm_target.Target.by_triple triple)
+  in
+
+  (* Generate asm code in a memory buffer for our target *)
+  let asmbuf =
+    Llvm_target.TargetMachine.emit_to_memory_buffer
+      md
+      Llvm_target.CodeGenFileType.AssemblyFile
+      tm
+  in
+
+  let asmstr = Llvm.MemoryBuffer.as_string asmbuf in
+
+  (* Compile asm to an executable using gcc - reading the asm from stdin *)
+  let argv = [ "gcc"; "-x"; "assembler"; "/dev/stdin"; "-o"; "a.out" ] in
+  let cmd = String.concat " " argv in
+  let child_stdout, child_stdin = Unix.open_process cmd in
+
+  (* Write the asm to the child's stdin *)
+  output_string child_stdin asmstr;
+  flush child_stdin;
+  (* send EOF *)
+  close_out child_stdin;
+
+  match Unix.close_process (child_stdout, child_stdin) with
+  | WEXITED 0 -> ()
+  | err ->
+    let msg =
+      match err with
+      | WEXITED n -> Printf.sprintf "exit: %d" n
+      | WSIGNALED s -> Printf.sprintf "signal: %d" s
+      | _ -> "unknown"
+    in
+    raise (Failure (Printf.sprintf "Failed to generate executable: error=%s\n" msg))
+;;
+
 let () =
   let channel = ref stdin in
   Arg.parse speclist (fun filename -> channel := open_in filename) usg;
-  (* read !channel *)
-  (* let lexbuf = Lexing.from_channel !channel in *)
   match !act with
   | Tokens -> read_and_print_tokens !channel
   | Ast -> read_and_print_ast !channel
-  | _ -> raise (Failure "not implemented")
+  | IR -> read_and_print_ir !channel
+  | Code -> read_and_compile !channel
 ;;

--- a/lib/dune
+++ b/lib/dune
@@ -4,7 +4,7 @@
 
 (library 
   (name fly_lib)
-  (libraries llvm))
+  (libraries llvm llvm.bitwriter llvm.target llvm.all_backends))
 
 (ocamllex scanner)
 (ocamlyacc parser)


### PR DESCRIPTION
fly executable CLI setup that receives a filename and one of these options:

- `--tokens`: print the tokens
- `--ast`: print the ast
- `--ir`: print the llvm ir

No flag means that a `fly.out` executable will be created in the user's current working directory.

If no filename is provided, the compiler will read the program from stdin. 
I do think it would be cool for the compiler to try to parse a `main.fly` instead if no filename is provided, but that's for later.