### PR TITLE
add `len()` and `input()` functions

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,5 +1,5 @@
 (executable 
   (name fly) 
   (public_name fly) 
-  (modules fly) 
+  (modules fly wrapper) 
   (libraries fly_lib))

--- a/bin/fly.ml
+++ b/bin/fly.ml
@@ -1,4 +1,5 @@
 open Fly_lib
+open Wrapper
 module L = Llvm
 
 type action =
@@ -55,48 +56,6 @@ let read_and_print_ir channel =
   let md = Irgen.translate sast in
   print_endline (L.string_of_llmodule md)
 ;;
-
-(* Reads all the bytes from a channel (not possible in ocaml for some reason) *)
-let read_all_from_channel (ic : in_channel) : bytes =
-  let buf = Buffer.create 4096 in
-  (try
-     while true do
-       Buffer.add_channel buf ic 1024
-     done
-   with
-   | End_of_file -> ());
-  Buffer.to_bytes buf
-;;
-
-(* We need to access libc specific stuff that is platform dependent: 
-    For example, the global "stdin" symbol in libc is actually called __stdinp on macos
-    We could either do a match case on which platform we're on, but instead 
-    We create c wrapper objects which allow us to use constant IR *)
-let compile_wrapper =
-  let wrapper = "#include <stdio.h>\nFILE *get_stdin() { return stdin; }" in
-  let argv = [ "clang"; "-x"; "c"; "-"; "-c"; "-o"; "/dev/stdout" ] in
-
-  let cmd = String.concat " " argv in
-  let child_stdout, child_stdin = Unix.open_process cmd in
-
-  (* Write into stdin *)
-  output_string child_stdin wrapper;
-  flush child_stdin;
-  (* Write EOF and close channel *)
-  close_out child_stdin;
-
-  let contents = read_all_from_channel child_stdout in
-
-  let filename = Filename.get_temp_dir_name () ^ "fly_wrapper.o" in
-  let pipe = open_out_bin filename in
-  output_bytes pipe contents;
-  close_out pipe;
-
-  filename
-;;
-
-(* Just delete the tmp file created with the wrapper object *)
-let cleanup_wrapper filename = Sys.remove filename
 
 let read_and_compile channel =
   let lexbuf = Lexing.from_channel channel in

--- a/bin/fly.ml
+++ b/bin/fly.ml
@@ -56,6 +56,7 @@ let read_and_print_ir channel =
   print_endline (L.string_of_llmodule md)
 ;;
 
+(* Reads all the bytes from a channel (not possible in ocaml for some reason) *)
 let read_all_from_channel (ic : in_channel) : bytes =
   let buf = Buffer.create 4096 in
   (try
@@ -78,14 +79,15 @@ let compile_wrapper =
   let cmd = String.concat " " argv in
   let child_stdout, child_stdin = Unix.open_process cmd in
 
+  (* Write into stdin *)
   output_string child_stdin wrapper;
   flush child_stdin;
+  (* Write EOF and close channel *)
   close_out child_stdin;
 
   let contents = read_all_from_channel child_stdout in
 
   let filename = Filename.get_temp_dir_name () ^ "fly_wrapper.o" in
-
   let pipe = open_out_bin filename in
   output_bytes pipe contents;
   close_out pipe;
@@ -93,6 +95,7 @@ let compile_wrapper =
   filename
 ;;
 
+(* Just delete the tmp file created with the wrapper object *)
 let cleanup_wrapper filename = Sys.remove filename
 
 let read_and_compile channel =

--- a/bin/fly.ml
+++ b/bin/fly.ml
@@ -56,6 +56,45 @@ let read_and_print_ir channel =
   print_endline (L.string_of_llmodule md)
 ;;
 
+let read_all_from_channel (ic : in_channel) : bytes =
+  let buf = Buffer.create 4096 in
+  (try
+     while true do
+       Buffer.add_channel buf ic 1024
+     done
+   with
+   | End_of_file -> ());
+  Buffer.to_bytes buf
+;;
+
+(* We need to access libc specific stuff that is platform dependent: 
+    For example, the global "stdin" symbol in libc is actually called __stdinp on macos
+    We could either do a match case on which platform we're on, but instead 
+    We create c wrapper objects which allow us to use constant IR *)
+let compile_wrapper =
+  let wrapper = "#include <stdio.h>\nFILE *get_stdin() { return stdin; }" in
+  let argv = [ "clang"; "-x"; "c"; "-"; "-c"; "-o"; "/dev/stdout" ] in
+
+  let cmd = String.concat " " argv in
+  let child_stdout, child_stdin = Unix.open_process cmd in
+
+  output_string child_stdin wrapper;
+  flush child_stdin;
+  close_out child_stdin;
+
+  let contents = read_all_from_channel child_stdout in
+
+  let filename = Filename.get_temp_dir_name () ^ "fly_wrapper.o" in
+
+  let pipe = open_out_bin filename in
+  output_bytes pipe contents;
+  close_out pipe;
+
+  filename
+;;
+
+let cleanup_wrapper filename = Sys.remove filename
+
 let read_and_compile channel =
   let lexbuf = Lexing.from_channel channel in
   let ast = Fly_lib.Parser.program_rule Fly_lib.Scanner.tokenize lexbuf in
@@ -79,8 +118,11 @@ let read_and_compile channel =
 
   let asmstr = Llvm.MemoryBuffer.as_string asmbuf in
 
-  (* Compile asm to an executable using gcc - reading the asm from stdin *)
-  let argv = [ "gcc"; "-x"; "assembler"; "/dev/stdin"; "-o"; exe_name ] in
+  (* Compile asm to an executable using clang - reading the asm from stdin *)
+  let tmp_filename = compile_wrapper in
+  let argv =
+    [ "gcc"; "-x"; "assembler"; "/dev/stdin"; "-x"; "none"; tmp_filename; "-o"; exe_name ]
+  in
   let cmd = String.concat " " argv in
   let child_stdout, child_stdin = Unix.open_process cmd in
 
@@ -90,16 +132,21 @@ let read_and_compile channel =
   (* send EOF *)
   close_out child_stdin;
 
-  match Unix.close_process (child_stdout, child_stdin) with
-  | WEXITED 0 -> ()
-  | err ->
-    let msg =
-      match err with
-      | WEXITED n -> Printf.sprintf "exit: %d" n
-      | WSIGNALED s -> Printf.sprintf "signal: %d" s
-      | _ -> "unknown"
-    in
-    raise (Failure (Printf.sprintf "Failed to generate executable: error=%s\n" msg))
+  (* Fun.protect ensures that the cleanup_wrapper (in the "finally" function) 
+     is always called, even if the match case raises *)
+  Fun.protect
+    ~finally:(fun () -> cleanup_wrapper tmp_filename)
+    (fun () ->
+       match Unix.close_process (child_stdout, child_stdin) with
+       | WEXITED 0 -> ()
+       | err ->
+         let msg =
+           match err with
+           | WEXITED n -> Printf.sprintf "exit: %d" n
+           | WSIGNALED s -> Printf.sprintf "signal: %d" s
+           | _ -> "unknown"
+         in
+         raise (Failure (Printf.sprintf "Failed to generate executable: error=%s\n" msg)))
 ;;
 
 let () =

--- a/bin/wrapper.ml
+++ b/bin/wrapper.ml
@@ -1,0 +1,46 @@
+(*
+   This file stores wrappers to c lib code
+*)
+
+(* We need to access libc specific stuff that is platform dependent: 
+    For example, the global "stdin" symbol in libc is actually called __stdinp on macos
+    We could either do a match case on which platform we're on, but instead 
+    We create c wrapper objects which allow us to use constant IR *)
+let wrapper = "#include <stdio.h>\nFILE *get_stdin() { return stdin; }"
+
+(* Reads all the bytes from a channel (not possible in ocaml for some reason) *)
+let read_all_from_channel (ic : in_channel) : bytes =
+  let buf = Buffer.create 4096 in
+  (try
+     while true do
+       Buffer.add_channel buf ic 1024
+     done
+   with
+   | End_of_file -> ());
+  Buffer.to_bytes buf
+;;
+
+let compile_wrapper =
+  let argv = [ "clang"; "-x"; "c"; "-"; "-c"; "-o"; "/dev/stdout" ] in
+
+  let cmd = String.concat " " argv in
+  let child_stdout, child_stdin = Unix.open_process cmd in
+
+  (* Write into stdin *)
+  output_string child_stdin wrapper;
+  flush child_stdin;
+  (* Write EOF and close channel *)
+  close_out child_stdin;
+
+  let contents = read_all_from_channel child_stdout in
+
+  let filename = Filename.get_temp_dir_name () ^ "fly_wrapper.o" in
+  let pipe = open_out_bin filename in
+  output_bytes pipe contents;
+  close_out pipe;
+
+  filename
+;;
+
+(* Just delete the tmp file created with the wrapper object *)
+let cleanup_wrapper filename = Sys.remove filename

--- a/lib/irgen.ml
+++ b/lib/irgen.ml
@@ -303,7 +303,7 @@ and prelude_input (_func : sfunc) _vars the_module builder =
     L.build_gep buffer [| L.const_int l_int 0; L.const_int l_int 0 |] "buffer_ptr" builder
   in
 
-  let stdin_val = L.build_call (get_stdin_fn the_module) [||] "stdin" builder in
+  let stdin_val = L.build_call (get_stdin_fn the_module) [||] "stdin_val" builder in
 
   let args = [| buffer_ptr; L.const_int l_int max_strlen; stdin_val |] in
   ignore (L.build_call (fgets_func the_module) args "call_fgets" builder);

--- a/lib/irgen.ml
+++ b/lib/irgen.ml
@@ -36,7 +36,6 @@ let ltype_of_typ = function
 
 let int_format_str builder = L.build_global_stringptr "%d\n" "int_fmt" builder
 let str_format_str builder = L.build_global_stringptr "%s\n" "str_fmt" builder
-let str_nonl_format_str builder = L.build_global_stringptr "%s" "str_fmt" builder
 let float_format_str builder = L.build_global_stringptr "%f\n" "float_fmt" builder
 
 (* Creates a binding to the llvm libc "printf" function *)
@@ -51,7 +50,7 @@ let strlen_func the_module = Llvm.declare_function "strlen" l_strlen the_module
 let l_scanf : L.lltype = L.var_arg_function_type l_int [| l_str |]
 let scanf_func the_module = L.declare_function "scanf" l_scanf the_module
 
-(* declare FILE struct *)
+(* declare FILE c struct *)
 let file_type = L.named_struct_type context "struct._IO_FILE"
 let _ = L.struct_set_body file_type [||] false
 let file_ptr_type = Llvm.pointer_type file_type
@@ -161,70 +160,64 @@ let rec build_expr expr (vars : variable StringMap.t) the_module builder =
     let typ = fst e1 in
     let se1 = build_expr e1 vars the_module builder in
     let se2 = build_expr e2 vars the_module builder in
-    if typ == A.String
-    then failwith "not implemented !!!"
-    (* let arr = [| se1 |] in *)
-    (* let _res = L.build_call (strlen_func the_module) arr "call_strlen" builder in *)
-    (* _res *)
-    else (
-      let lval =
-        match typ with
-        | A.Int ->
-          (match op with
-           | A.Add -> L.build_add
-           | A.Sub -> L.build_sub
-           | A.Mult -> L.build_mul
-           | A.Div -> L.build_sdiv
-           | A.Mod -> L.build_srem
-           | A.Equal -> L.build_icmp L.Icmp.Eq
-           | A.Neq -> L.build_icmp L.Icmp.Ne
-           | A.Less -> L.build_icmp L.Icmp.Slt
-           | A.Leq -> L.build_icmp L.Icmp.Sle
-           | A.Greater -> L.build_icmp L.Icmp.Sgt
-           | A.Geq -> L.build_icmp L.Icmp.Sge
-           | _ ->
-             failwith
-               (Printf.sprintf
-                  "Integer binary operator %s not yet implemented"
-                  (Utils.string_of_op op)))
-        | A.Float ->
-          (match op with
-           | A.Add -> L.build_fadd
-           | A.Sub -> L.build_fsub
-           | A.Mult -> L.build_fmul
-           | A.Div -> L.build_fdiv
-           | A.Mod -> L.build_frem
-           | A.Equal -> L.build_fcmp L.Fcmp.Oeq
-           | A.Neq -> L.build_fcmp L.Fcmp.One
-           | A.Less -> L.build_fcmp L.Fcmp.Olt
-           | A.Leq -> L.build_fcmp L.Fcmp.Ole
-           | A.Greater -> L.build_fcmp L.Fcmp.Ogt
-           | A.Geq -> L.build_fcmp L.Fcmp.Oge
-           | _ ->
-             failwith
-               (Printf.sprintf
-                  "Float binary operator %s not yet implemented"
-                  (Utils.string_of_op op)))
-        | A.Bool ->
-          (match op with
-           | A.And -> L.build_and
-           | A.Or -> L.build_or
-           | A.Equal -> L.build_icmp L.Icmp.Eq
-           | A.Neq -> L.build_icmp L.Icmp.Ne
-           | _ ->
-             failwith
-               (Printf.sprintf
-                  "Boolean binary operator %s not yet implemented"
-                  (Utils.string_of_op op)))
-        | A.String -> failwith "GOT A STRING\n"
-        | _ ->
-          failwith
-            (Printf.sprintf
-               "Binary operator %s not yet implemented for type %s"
-               (Utils.string_of_op op)
-               (Utils.string_of_type typ))
-      in
-      lval se1 se2 ("tmp_" ^ Utils.string_of_type typ) builder)
+    let lval =
+      match typ with
+      | A.Int ->
+        (match op with
+         | A.Add -> L.build_add
+         | A.Sub -> L.build_sub
+         | A.Mult -> L.build_mul
+         | A.Div -> L.build_sdiv
+         | A.Mod -> L.build_srem
+         | A.Equal -> L.build_icmp L.Icmp.Eq
+         | A.Neq -> L.build_icmp L.Icmp.Ne
+         | A.Less -> L.build_icmp L.Icmp.Slt
+         | A.Leq -> L.build_icmp L.Icmp.Sle
+         | A.Greater -> L.build_icmp L.Icmp.Sgt
+         | A.Geq -> L.build_icmp L.Icmp.Sge
+         | _ ->
+           failwith
+             (Printf.sprintf
+                "Integer binary operator %s not yet implemented"
+                (Utils.string_of_op op)))
+      | A.Float ->
+        (match op with
+         | A.Add -> L.build_fadd
+         | A.Sub -> L.build_fsub
+         | A.Mult -> L.build_fmul
+         | A.Div -> L.build_fdiv
+         | A.Mod -> L.build_frem
+         | A.Equal -> L.build_fcmp L.Fcmp.Oeq
+         | A.Neq -> L.build_fcmp L.Fcmp.One
+         | A.Less -> L.build_fcmp L.Fcmp.Olt
+         | A.Leq -> L.build_fcmp L.Fcmp.Ole
+         | A.Greater -> L.build_fcmp L.Fcmp.Ogt
+         | A.Geq -> L.build_fcmp L.Fcmp.Oge
+         | _ ->
+           failwith
+             (Printf.sprintf
+                "Float binary operator %s not yet implemented"
+                (Utils.string_of_op op)))
+      | A.Bool ->
+        (match op with
+         | A.And -> L.build_and
+         | A.Or -> L.build_or
+         | A.Equal -> L.build_icmp L.Icmp.Eq
+         | A.Neq -> L.build_icmp L.Icmp.Ne
+         | _ ->
+           failwith
+             (Printf.sprintf
+                "Boolean binary operator %s not yet implemented"
+                (Utils.string_of_op op)))
+      | A.String -> failwith "GOT A STRING\n"
+      | _ ->
+        failwith
+          (Printf.sprintf
+             "Binary operator %s not yet implemented for type %s"
+             (Utils.string_of_op op)
+             (Utils.string_of_type typ))
+    in
+    lval se1 se2 ("tmp_" ^ Utils.string_of_type typ) builder
   | SStringLit s -> L.build_global_stringptr s "str" builder
   | e ->
     raise (Failure (Printf.sprintf "expr not implemented: %s" (Utils.string_of_sexpr e)))

--- a/lib/irgen.ml
+++ b/lib/irgen.ml
@@ -427,7 +427,6 @@ let add_global_val typ var (vars : variable StringMap.t) _ expr the_module =
       let init = L.const_int l_int i in
       L.define_global var init the_module
     | A.String, SStringLit s ->
-      Printf.printf "STRING: %s\n" s;
       (* Create fake temporary function to create a builder *)
       let temp_fn_type = L.function_type (L.void_type context) [||] in
       let temp_fn = L.define_function "temp_fn" temp_fn_type the_module in

--- a/lib/sast.ml
+++ b/lib/sast.ml
@@ -63,10 +63,13 @@ type sblock =
   | SReturnVal of sexpr
   | SExpr of sexpr
 
-(* Name of our print function *)
+(* Name of our "print" function *)
 let print_func_name = "print"
 
-(* Name of our len function *)
+(* Name of our "len" function *)
 let len_func_name = "len"
+
+(* Name of our "input" function *)
+let input_func_name = "input"
 
 type sprogram = { body : sblock list }

--- a/lib/sast.ml
+++ b/lib/sast.ml
@@ -66,4 +66,7 @@ type sblock =
 (* Name of our print function *)
 let print_func_name = "print"
 
+(* Name of our len function *)
+let len_func_name = "len"
+
 type sprogram = { body : sblock list }

--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -597,11 +597,14 @@ let check block_list =
   (* Add "print" function *)
   let new_func_env = func_def_helper Sast.print_func_name [] Ast.Unit initial_envs in
   let envs = { initial_envs with func_env = new_func_env } in
+  (* Add "len" function *)
+  let new_func_env2 = func_def_helper Sast.len_func_name [] Ast.Int envs in
+  let envs2 = { envs with func_env = new_func_env2 } in
 
   (* Special blocks are limited to return, continue, break, wildcard.
    We need this to indicate whether these symbols are allowed in their current context.
    For example, a return is only allowed inside a function defintion and a break is only allowed inside a loop 
    I should really come up with a better name for this *)
   let special_blocks = StringSet.empty in
-  check_block_list block_list envs special_blocks Unit
+  check_block_list block_list envs2 special_blocks Unit
 ;;

--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -601,10 +601,14 @@ let check block_list =
   let new_func_env2 = func_def_helper Sast.len_func_name [] Ast.Int envs in
   let envs2 = { envs with func_env = new_func_env2 } in
 
+  (* Add "input" function *)
+  let new_func_env3 = func_def_helper Sast.input_func_name [] Ast.String envs2 in
+  let envs3 = { envs2 with func_env = new_func_env3 } in
+
   (* Special blocks are limited to return, continue, break, wildcard.
    We need this to indicate whether these symbols are allowed in their current context.
    For example, a return is only allowed inside a function defintion and a break is only allowed inside a loop 
    I should really come up with a better name for this *)
   let special_blocks = StringSet.empty in
-  check_block_list block_list envs2 special_blocks Unit
+  check_block_list block_list envs3 special_blocks Unit
 ;;

--- a/test/ir/dune
+++ b/test/ir/dune
@@ -11,9 +11,9 @@
   (libraries fly_lib ounit2))
 
 (test
-  (name test_print)
+  (name test_string)
   (libraries fly_lib ounit2))
 
 (test
-  (name test_string)
+  (name test_prelude)
   (libraries fly_lib ounit2))

--- a/test/ir/test_prelude.ml
+++ b/test/ir/test_prelude.ml
@@ -158,6 +158,31 @@ let tests =
           in
           (* _write_to_file actual "actual.out"; *)
           assert_equal expected actual ~printer)
+       ; ("input"
+          >:: fun _ ->
+          let sast = get_sast "fun main() {let str := input(); return; }" in
+          let mdl = Irgen.translate sast in
+          let actual = L.string_of_llmodule mdl in
+          let expected =
+            "; ModuleID = 'Fly'\n\
+             source_filename = \"Fly\"\n\n\
+             %struct._IO_FILE = type {}\n\n\
+             define void @main() {\n\
+             entry:\n\
+            \  %str = alloca i8*, align 8\n\
+            \  %buffer = alloca [100 x i8], align 1\n\
+            \  %buffer_ptr = getelementptr [100 x i8], [100 x i8]* %buffer, i32 0, i32 0\n\
+            \  %stdin_val = call %struct._IO_FILE* @get_stdin()\n\
+            \  %call_fgets = call i8* @fgets(i8* %buffer_ptr, i32 100, %struct._IO_FILE* \
+             %stdin_val)\n\
+            \  store i8* %buffer_ptr, i8** %str, align 8\n\
+            \  ret void\n\
+             }\n\n\
+             declare %struct._IO_FILE* @get_stdin()\n\n\
+             declare i8* @fgets(i8*, i32, %struct._IO_FILE*)\n"
+          in
+          (* _write_to_file actual "actual.out"; *)
+          assert_equal expected actual ~printer)
        ]
 ;;
 

--- a/test/ir/test_prelude.ml
+++ b/test/ir/test_prelude.ml
@@ -180,7 +180,7 @@ let tests =
              declare %struct._IO_FILE* @get_stdin()\n\n\
              declare i8* @fgets(i8*, i32, %struct._IO_FILE*)\n"
           in
-          _write_to_file actual "actual.out";
+          (* _write_to_file actual "actual.out"; *)
           assert_equal expected actual ~printer)
        ]
 ;;

--- a/test/ir/test_prelude.ml
+++ b/test/ir/test_prelude.ml
@@ -26,7 +26,7 @@ let _write_to_file text filename =
 ;;
 
 let tests =
-  "testing_prints"
+  "testing_preludes"
   >::: [ (* ("print_nothing" *)
          (*     >:: fun _ -> *)
          (*     let sast = get_sast "fun main() -> int {print(); return 0;}" in *)
@@ -54,8 +54,8 @@ let tests =
              @int_fmt = private unnamed_addr constant [4 x i8] c\"%d\\0A\\00\", align 1\n\n\
              define i32 @main() {\n\
              entry:\n\
-            \  %printf = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x \
-             i8], [4 x i8]* @int_fmt, i32 0, i32 0), i32 1)\n\
+            \  %call_printf = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 \
+             x i8], [4 x i8]* @int_fmt, i32 0, i32 0), i32 1)\n\
             \  ret i32 0\n\
              }\n\n\
              declare i32 @printf(i8*, ...)\n"
@@ -73,8 +73,8 @@ let tests =
              1\n\n\
              define i32 @main() {\n\
              entry:\n\
-            \  %printf = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x \
-             i8], [4 x i8]* @float_fmt, i32 0, i32 0), float 0x3FF3AE1480000000)\n\
+            \  %call_printf = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 \
+             x i8], [4 x i8]* @float_fmt, i32 0, i32 0), float 0x3FF3AE1480000000)\n\
             \  ret i32 0\n\
              }\n\n\
              declare i32 @printf(i8*, ...)\n"
@@ -105,8 +105,8 @@ let tests =
             \  %bool_str = phi i8* [ getelementptr inbounds ([5 x i8], [5 x i8]* \
              @true_str, i32 0, i32 0), %true_case ], [ getelementptr inbounds ([6 x i8], \
              [6 x i8]* @false_str, i32 0, i32 0), %false_case ]\n\
-            \  %printf = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x \
-             i8], [4 x i8]* @str_fmt, i32 0, i32 0), i8* %bool_str)\n\
+            \  %call_printf = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 \
+             x i8], [4 x i8]* @str_fmt, i32 0, i32 0), i8* %bool_str)\n\
             \  ret i32 0\n\
              }\n\n\
              declare i32 @printf(i8*, ...)\n"
@@ -124,14 +124,39 @@ let tests =
              @str_fmt = private unnamed_addr constant [4 x i8] c\"%s\\0A\\00\", align 1\n\n\
              define i32 @main() {\n\
              entry:\n\
-            \  %printf = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x \
-             i8], [4 x i8]* @str_fmt, i32 0, i32 0), i8* getelementptr inbounds ([6 x \
+            \  %call_printf = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 \
+             x i8], [4 x i8]* @str_fmt, i32 0, i32 0), i8* getelementptr inbounds ([6 x \
              i8], [6 x i8]* @str, i32 0, i32 0))\n\
             \  ret i32 0\n\
              }\n\n\
              declare i32 @printf(i8*, ...)\n"
           in
-          _write_to_file actual "test.out";
+          (* _write_to_file actual "test.out"; *)
+          assert_equal expected actual ~printer)
+       ; ("len"
+          >:: fun _ ->
+          let sast =
+            get_sast "fun main() {let str := \"hello\"; let strlen := len(str); }"
+          in
+          let mdl = Irgen.translate sast in
+          let actual = L.string_of_llmodule mdl in
+          let expected =
+            "; ModuleID = 'Fly'\n\
+             source_filename = \"Fly\"\n\n\
+             @str = private unnamed_addr constant [6 x i8] c\"hello\\00\", align 1\n\n\
+             define void @main() {\n\
+             entry:\n\
+            \  %str = alloca i8*, align 8\n\
+            \  store i8* getelementptr inbounds ([6 x i8], [6 x i8]* @str, i32 0, i32 \
+             0), i8** %str, align 8\n\
+            \  %strlen = alloca i32, align 4\n\
+            \  %str1 = load i8*, i8** %str, align 8\n\
+            \  %call_strlen = call i32 @strlen(i8* %str1)\n\
+            \  store i32 %call_strlen, i32* %strlen, align 4\n\
+             }\n\n\
+             declare i32 @strlen(i8*)\n"
+          in
+          (* _write_to_file actual "actual.out"; *)
           assert_equal expected actual ~printer)
        ]
 ;;

--- a/test/type_checker/dune
+++ b/test/type_checker/dune
@@ -9,3 +9,7 @@
 (test
   (name test_loops)
   (libraries fly_lib ounit2))
+
+(test
+  (name test_expr)
+  (libraries fly_lib ounit2))

--- a/test/type_checker/dune
+++ b/test/type_checker/dune
@@ -1,15 +1,11 @@
 (test
-  (name test_and)
-  (libraries fly_lib ounit2))
+ (name test_and)
+ (libraries fly_lib ounit2))
 
 (test
-  (name test_divide)
-  (libraries fly_lib ounit2))
+ (name test_divide)
+ (libraries fly_lib ounit2))
 
 (test
-  (name test_loops)
-  (libraries fly_lib ounit2))
-
-(test
-  (name test_expr)
-  (libraries fly_lib ounit2))
+ (name test_loops)
+ (libraries fly_lib ounit2))


### PR DESCRIPTION
now we can call len() on strings, as well as input() to read a line from stdin.

Note that input() is a wrapper on libc's `fgets`, which requires using C's `FILE * stdin` variable. 
The reason for using fgets instead of scanf is that scanf stops parsing a string on whitespace, whereas fgets reads the entire string until a newline is found.

A problem with the `stdin` variable is that it has different names on differnet platforms (on macos it's `__stdinp` (image below)).
I solved this by creating a new object file which creates a wrapper around the stdin variable. This wrapper function is called `get_stdin()`, and is the reason why IR code from fly programs using `input()` can't be compiled without linking with this wrapper object.


<img width="510" alt="image" src="https://github.com/user-attachments/assets/e8004413-4cfd-468c-b024-e6be54e4764c" />


wrap.c LLVM ir:
```
@__stdinp = external global ptr, align 8

; Function Attrs: noinline nounwind optnone ssp uwtable(sync)
define ptr @get_stdin() #0 {
  %1 = load ptr, ptr @__stdinp, align 8
  ret ptr %1
}
```